### PR TITLE
Configurable save job

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,15 +13,15 @@ mod storage;
 
 #[derive(Parser, Debug)]
 struct Args {
-    // Port to run the server
+    /// Port to run the server
     #[arg(short, long, default_value_t = 7777)]
     port: u16,
 
-    // Number of shards
+    /// Number of shards
     #[arg(short, long, default_value_t = 8)]
     shards: usize,
 
-    // Enable the background job to save the data to disk
+    /// Enable the scheduled background job to save the data to disk
     #[arg(short, long, default_value_t = false)]
     enable_save_job: bool,
 }


### PR DESCRIPTION
Adds a CLI option to configure the interval between save jobs. The
default is set to 60 minutes. Also fixes the documentation on the Args
struct.