### PR TITLE
Moves extracts response formatting from storage to main

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,3 +14,32 @@ impl fmt::Display for SsacheErrorKind {
 }
 
 impl Error for SsacheErrorKind {}
+
+#[derive(Debug, PartialEq)]
+pub enum SaveErrorKind {
+    UnableToCreateDump,
+    UnableToWriteToDump,
+    UnableToSerializeIntoBinary,
+}
+
+impl fmt::Display for SaveErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Error on save")
+    }
+}
+
+impl Error for SaveErrorKind {}
+
+#[derive(Debug, PartialEq)]
+pub enum LoadErrorKind {
+    UnableToDeserializaData,
+    UnableToReadDump,
+}
+
+impl fmt::Display for LoadErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Error on load")
+    }
+}
+
+impl Error for LoadErrorKind {}


### PR DESCRIPTION
Separates the resposibility of storage and response formatting, the storage module should only deal with the internal data structures and the main function deals with the response formatting.