### PR TITLE
Cache expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To send the commands to ssache you need to stablish a tcp connection, the protoc
 
 - GET
 - SET
+- EXPIRE
 - SAVE
 - LOAD
 - PING
@@ -19,8 +20,6 @@ To send the commands to ssache you need to stablish a tcp connection, the protoc
 
 ## TODOs
 
-- Define ttl to data
-  - Implement EXPIRE and EX on GET
 - Support storing integers
   - Implement INCR and DECR
 - Distributed storage
@@ -51,7 +50,6 @@ Connected to 127.0.0.1.
 Escape character is '^]'.
 SET key some-value
 +OK
-Connection closed by foreign host.
 ```
 
 ### GET
@@ -66,7 +64,21 @@ Escape character is '^]'.
 GET key
 $10
 +some-value
-Connection closed by foreign host.
+```
+
+### EXPIRE
+
+EXPIRE [key] [ttl]
+
+Sets expiration time for a key, the ttl is set in milliseconds.
+
+```shell
+$ telnet 127.0.0.1 7777
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+EXPIRE key 1000
++OK
 ```
 
 ### QUIT
@@ -78,7 +90,6 @@ Connected to 127.0.0.1.
 Escape character is '^]'.
 QUIT
 +OK
-Connection closed by foreign host.
 ```
 
 ### SAVE
@@ -92,7 +103,6 @@ Connected to 127.0.0.1.
 Escape character is '^]'.
 SAVE
 +OK
-Connection closed by foreign host.
 ```
 
 ### LOAD
@@ -106,7 +116,6 @@ Connected to 127.0.0.1.
 Escape character is '^]'.
 LOAD
 +OK
-Connection closed by foreign host.
 ```
 ### PING
 
@@ -119,7 +128,6 @@ Connected to 127.0.0.1.
 Escape character is '^]'.
 PING
 +PONG
-Connection closed by foreign host.
 ```
 
 ```shell
@@ -130,7 +138,6 @@ Escape character is '^]'.
 PING message
 $7
 +message
-Connection closed by foreign host.
 ```
 
 ### QUIT
@@ -142,7 +149,6 @@ Connected to 127.0.0.1.
 Escape character is '^]'.
 QUIT
 +OK
-Connection closed by foreign host.
 ```
 
 [0]: https://redis.io/

--- a/tests/expiration_test.py
+++ b/tests/expiration_test.py
@@ -1,0 +1,25 @@
+from time import sleep
+
+from ssache_client import CRLF, SsacheClient
+
+client = SsacheClient()
+
+# Set and Get key with single word on value
+client.connect()
+response = client.set("key", "value")
+expected_response = f"+OK{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.get("key")
+expected_response = f"$5{CRLF}+value{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.expire("key", 2000)
+expected_response = f"+OK{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+sleep(3)
+
+response = client.get("key")
+expected_response = f"$-1{CRLF}"
+assert response.decode("utf-8") == expected_response

--- a/tests/ssache_client.py
+++ b/tests/ssache_client.py
@@ -52,6 +52,11 @@ class SsacheClient:
         self.__socket.send(request.encode("utf-8"))
         return self.__socket.recv(1024)
 
+    def expire(self, key, ttl):
+        request = f"EXPIRE {key} {ttl}{CRLF}"
+        self.__socket.send(request.encode("utf-8"))
+        return self.__socket.recv(1024)
+
     def save(self):
         request = f"SAVE{CRLF}"
         self.__socket.send(request.encode("utf-8"))


### PR DESCRIPTION
Adds cache expiration withe the `EXPIRE` command, the client may set a TTL for a given key and a background job checks for expired keys and removes them from the shards.