### PR TITLE
Add commands to increment and decrement values

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ system that i can use on my own website.
 
 ## Commands supported
 
-To send the commands to ssache you need to stablish a tcp connection, the protocol used is based on [RESP][1].
+To send the commands to ssache you need to stablish a tcp connection,
+the protocol used is based on [RESP][1].
 
 - GET
 - SET
 - EXPIRE
+- INCR
+- DECR
 - SAVE
 - LOAD
 - PING
@@ -20,8 +23,6 @@ To send the commands to ssache you need to stablish a tcp connection, the protoc
 
 ## TODOs
 
-- Support storing integers
-  - Implement INCR and DECR
 - Distributed storage
   - Simple last write wins algorithm
 
@@ -79,6 +80,38 @@ Connected to 127.0.0.1.
 Escape character is '^]'.
 EXPIRE key 1000
 +OK
+```
+
+### INCR
+
+Increments the value stored in a [key], initializes with zero if the
+key doesn't exist. Returns the incremented value.
+
+INCR [key]
+
+```shell
+$ telnet 127.0.0.1 7777
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+INCR key
+:0
+```
+
+### DECR
+
+Decrements the value stored in a [key], initializes with zero if the
+key doesn't exist. Returns the incremented value.
+
+DECR [key]
+
+```shell
+$ telnet 127.0.0.1 7777
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+DECR key
+:0
 ```
 
 ### QUIT

--- a/src/command.rs
+++ b/src/command.rs
@@ -12,6 +12,10 @@ pub enum Command {
     Set { key: String, value: String },
     // EXPIRE key time(in milliseconds)
     Expire { key: String, time: Duration },
+    // INCR key
+    Incr { key: String },
+    // DECR key
+    Decr { key: String },
     // SAVE
     Save,
     // LOAD
@@ -63,6 +67,26 @@ pub fn parse_command(command_line: Vec<String>) -> Result<Command, SsacheError> 
         }
     } else if command.eq(&String::from("SAVE")) {
         Ok(Command::Save)
+    } else if command.eq(&String::from("INCR")) {
+        if let Some(key) = command_line.get(1) {
+            Ok(Command::Incr {
+                key: key.to_string(),
+            })
+        } else {
+            debug!("not enough parameters for INCR command");
+            let message = format!("-ERROR not enough parameters for INCR{CRLF}");
+            Err(SsacheError::NotEnoughParameters { message })
+        }
+    } else if command.eq(&String::from("DECR")) {
+        if let Some(key) = command_line.get(1) {
+            Ok(Command::Decr {
+                key: key.to_string(),
+            })
+        } else {
+            debug!("not enough parameters for DECR command");
+            let message = format!("-ERROR not enough parameters for DECR{CRLF}");
+            Err(SsacheError::NotEnoughParameters { message })
+        }
     } else if command.eq(&String::from("LOAD")) {
         Ok(Command::Load)
     } else if command.eq(&String::from("QUIT")) {
@@ -278,6 +302,60 @@ mod tests {
             Command::Expire {
                 key: "key".to_string(),
                 time: Duration::from_millis(1000)
+            }
+        );
+    }
+
+    #[test]
+    fn parse_incr_command_without_enough_arguments() {
+        let mut command_line = Vec::new();
+        command_line.push("INCR".to_string());
+
+        let result = parse_command(command_line);
+
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn parse_incr_command_with_enough_arguments() {
+        let mut command_line = Vec::new();
+        command_line.push("INCR".to_string());
+        command_line.push("key".to_string());
+
+        let result = parse_command(command_line);
+
+        assert_eq!(result.is_ok(), true);
+        assert_eq!(
+            result.unwrap(),
+            Command::Incr {
+                key: "key".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_decr_command_without_enough_arguments() {
+        let mut command_line = Vec::new();
+        command_line.push("DECR".to_string());
+
+        let result = parse_command(command_line);
+
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn parse_decr_command_with_enough_arguments() {
+        let mut command_line = Vec::new();
+        command_line.push("DECR".to_string());
+        command_line.push("key".to_string());
+
+        let result = parse_command(command_line);
+
+        assert_eq!(result.is_ok(), true);
+        assert_eq!(
+            result.unwrap(),
+            Command::Decr {
+                key: "key".to_string()
             }
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,60 @@ async fn handle_request(
             stream.write_all(response.as_bytes()).await.unwrap();
             Ok(())
         }
+        command::Command::Incr { key } => {
+            let response = match storage.incr(key).await {
+                Ok(value) => format!(":{value}{CRLF}"),
+                Err(e) => {
+                    match e.kind() {
+                        std::num::IntErrorKind::Empty => {
+                            format!("-ERROR the value is empty, impossible to convert to a number{CRLF}")
+                        }
+                        std::num::IntErrorKind::InvalidDigit => {
+                            format!("-ERROR the value is not a valid number{CRLF}")
+                        }
+                        std::num::IntErrorKind::NegOverflow => {
+                            format!("-ERROR negative overflow{CRLF}")
+                        }
+                        std::num::IntErrorKind::PosOverflow => {
+                            format!("-ERROR positive overflow{CRLF}")
+                        }
+                        &_ => {
+                            debug!("unkwon error incrementing key {}", e);
+                            format!("-ERROR unknown error {CRLF}")
+                        }
+                    }
+                }
+            };
+            stream.write_all(response.as_bytes()).await.unwrap();
+            Ok(())
+        }
+        command::Command::Decr { key } => {
+            let response = match storage.decr(key).await {
+                Ok(value) => format!(":{value}{CRLF}"),
+                Err(e) => {
+                    match e.kind() {
+                        std::num::IntErrorKind::Empty => {
+                            format!("-ERROR the value is empty, impossible to convert to a number{CRLF}")
+                        }
+                        std::num::IntErrorKind::InvalidDigit => {
+                            format!("-ERROR the value is not a valid number{CRLF}")
+                        }
+                        std::num::IntErrorKind::NegOverflow => {
+                            format!("-ERROR negative overflow{CRLF}")
+                        }
+                        std::num::IntErrorKind::PosOverflow => {
+                            format!("-ERROR positive overflow{CRLF}")
+                        }
+                        &_ => {
+                            debug!("unkwon error incrementing key {}", e);
+                            format!("-ERROR unknown error {CRLF}")
+                        }
+                    }
+                }
+            };
+            stream.write_all(response.as_bytes()).await.unwrap();
+            Ok(())
+        }
         command::Command::Save => {
             let response = match storage.save().await {
                 Ok(()) => format!("+OK{CRLF}"),

--- a/tests/incr_and_decr_test.py
+++ b/tests/incr_and_decr_test.py
@@ -1,0 +1,114 @@
+from ssache_client import CRLF, SsacheClient
+
+client = SsacheClient()
+
+# Set key and increment
+client.connect()
+response = client.set("key", "1")
+expected_response = f"+OK{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.incr("key")
+expected_response = f":2{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.get("key")
+expected_response = f"$1{CRLF}+2{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+# Set key and increment twice
+response = client.set("key", "1")
+expected_response = f"+OK{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.incr("key")
+expected_response = f":2{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.incr("key")
+expected_response = f":3{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.get("key")
+expected_response = f"$1{CRLF}+3{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+# Increment key without set
+response = client.incr("key-without-value")
+expected_response = f":0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.get("key-without-value")
+expected_response = f"$1{CRLF}+0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+# Increment key with string stored
+response = client.set("key", "value")
+expected_response = f"+OK{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.incr("key")
+expected_response = f"-ERROR the value is not a valid number{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+# Set key and decrement
+client.connect()
+response = client.set("key", "1")
+expected_response = f"+OK{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.decr("key")
+expected_response = f":0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.get("key")
+expected_response = f"$1{CRLF}+0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+# Set key and decrement twice
+response = client.set("key", "2")
+expected_response = f"+OK{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.decr("key")
+expected_response = f":1{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.decr("key")
+expected_response = f":0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.get("key")
+expected_response = f"$1{CRLF}+0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+# Decrement key without set
+response = client.decr("key-without-value-decr")
+expected_response = f":0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.get("key-without-value-decr")
+expected_response = f"$1{CRLF}+0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+# Decrement key to negative value
+response = client.decr("negative-value")
+expected_response = f":0{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.decr("negative-value")
+expected_response = f":-1{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.get("negative-value")
+expected_response = f"$2{CRLF}+-1{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+# Decrement key with string stored
+response = client.set("key", "value")
+expected_response = f"+OK{CRLF}"
+assert response.decode("utf-8") == expected_response
+
+response = client.decr("key")
+expected_response = f"-ERROR the value is not a valid number{CRLF}"
+assert response.decode("utf-8") == expected_response

--- a/tests/ssache_client.py
+++ b/tests/ssache_client.py
@@ -65,6 +65,16 @@ class SsacheClient:
         self.__socket.send(request.encode("utf-8"))
         return self.__socket.recv(1024)
 
+    def incr(self, key):
+        request = f"INCR {key}{CRLF}"
+        self.__socket.send(request.encode("utf-8"))
+        return self.__socket.recv(1024)
+
+    def decr(self, key):
+        request = f"DECR {key}{CRLF}"
+        self.__socket.send(request.encode("utf-8"))
+        return self.__socket.recv(1024)
+
     def save(self):
         request = f"SAVE{CRLF}"
         self.__socket.send(request.encode("utf-8"))


### PR DESCRIPTION
Add the INCR and DECR commands, they will be used to increment and decrement values stored. The storage still saves the value of everything as a string for now. INCR and DECR read the value and try to parse to a signed 64-bit integer.