### PR TITLE
Add asynchronous replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ the protocol used is based on [RESP][1].
 - PING
 - QUIT
 
-## TODOs
-
-- Distributed storage
-  - Simple last write wins algorithm
-
 ## Building
 
 ```shell

--- a/tests/load_and_save_test.py
+++ b/tests/load_and_save_test.py
@@ -1,9 +1,10 @@
-import os
-import signal
-
-import psutil
-
-from ssache_client import CRLF, SsacheClient, initialize_ssache, kill_ssache
+from ssache_client import (
+    CRLF,
+    SsacheClient,
+    find_and_kill_ssache_process,
+    initialize_ssache,
+    kill_ssache,
+)
 
 
 def set_and_check(client, key):
@@ -36,12 +37,7 @@ response = client.save()
 expected_response = f"+OK{CRLF}"
 assert response.decode("utf-8") == expected_response
 
-# Workaround to kill the running ssache process and restart it
-processes = psutil.process_iter()
-
-name = "ssache"
-ssache_process = [p for p in processes if name in p.name()][0]
-os.kill(ssache_process.pid, signal.SIGTERM)
+find_and_kill_ssache_process()
 
 pid = initialize_ssache()
 

--- a/tests/replication_test.py
+++ b/tests/replication_test.py
@@ -1,0 +1,85 @@
+from time import sleep
+
+from ssache_client import (
+    CRLF,
+    SsacheClient,
+    find_and_kill_ssache_process,
+    initialize_ssache,
+    kill_ssache,
+)
+
+# Kill main process to reinitialize with replicas configuration
+find_and_kill_ssache_process()
+
+replica_1_pid = initialize_ssache(7778)
+replica_2_pid = initialize_ssache(7779)
+primary_pid = initialize_ssache(
+    port=7777,
+    args="-r --replicas 127.0.0.1:7778 --replicas 127.0.0.1:7779 --replication-interval 1",
+)
+
+primary_client = SsacheClient()
+primary_client.connect()
+
+try:
+    # Testing replication of key overwrite
+    for i in range(10):
+        response = primary_client.set("key", str(i))
+        expected_response = f"+OK{CRLF}"
+        assert response.decode("utf-8") == expected_response
+
+    # Wait a little more than one minute so that the replication job may run
+    sleep(65)
+
+    for port in [7778, 7779]:
+        client = SsacheClient()
+        client.connect(port)
+        response = client.get("key")
+        expected_response = f"$1{CRLF}+9{CRLF}"
+        assert response.decode("utf-8") == expected_response
+
+    # Testing replication with multiple different keys
+    for i in range(25):
+        response = primary_client.set(f"key-{i}", f"value-{i:02d}")
+        expected_response = f"+OK{CRLF}"
+        assert response.decode("utf-8") == expected_response
+
+    # Wait a little more than one minute so that the replication job may run
+    sleep(65)
+
+    for port in [7778, 7779]:
+        client = SsacheClient()
+        client.connect(port)
+        for i in range(25):
+            response = client.get(f"key-{i}")
+            expected_response = f"$8{CRLF}+value-{i:02d}{CRLF}"
+            assert response.decode("utf-8") == expected_response
+
+    # Testing replication increments and decrements
+    response = primary_client.set("int-key", "0")
+    expected_response = f"+OK{CRLF}"
+    assert response.decode("utf-8") == expected_response
+
+    for i in range(3):
+        response = primary_client.incr("int-key")
+        expected_response = f":{i+1}{CRLF}"
+        assert response.decode("utf-8") == expected_response
+
+    for i in range(3, 0, -1):
+        response = primary_client.decr("int-key")
+        expected_response = f":{i-1}{CRLF}"
+        assert response.decode("utf-8") == expected_response
+
+    # Wait a little more than one minute so that the replication job may run
+    sleep(65)
+
+    for port in [7778, 7779]:
+        client = SsacheClient()
+        client.connect(port)
+        response = client.get("int-key")
+        expected_response = f"$1{CRLF}+0{CRLF}"
+        assert response.decode("utf-8") == expected_response
+finally:
+    kill_ssache(replica_1_pid)
+    kill_ssache(replica_2_pid)
+    kill_ssache(primary_pid)

--- a/tests/scheduled_save_job_test.py
+++ b/tests/scheduled_save_job_test.py
@@ -1,13 +1,10 @@
-import os
-import signal
 from time import sleep
-
-import psutil
 
 from ssache_client import (
     CRLF,
     SsacheClient,
-    initialize_ssache_with_scheduled_save,
+    find_and_kill_ssache_process,
+    initialize_ssache,
     kill_ssache,
 )
 
@@ -30,13 +27,9 @@ def get_and_check_found_value(client, key):
     assert response.decode("utf-8") == expected_response
 
 
-# Workaround to kill the running ssache process and restart it
-processes = psutil.process_iter()
-name = "ssache"
-ssache_process = [p for p in processes if name in p.name()][0]
-os.kill(ssache_process.pid, signal.SIGTERM)
+find_and_kill_ssache_process()
 
-pid = initialize_ssache_with_scheduled_save("1")
+pid = initialize_ssache(args="-e --save-job-interval 1")
 try:
     client = SsacheClient()
     client.connect()
@@ -52,7 +45,7 @@ finally:
     kill_ssache(pid)
 
 
-pid = initialize_ssache_with_scheduled_save("1")
+pid = initialize_ssache(args="-e --save-job-interval 1")
 
 try:
     client.connect()

--- a/tests/ssache_client.py
+++ b/tests/ssache_client.py
@@ -3,25 +3,31 @@ import signal
 import socket as s
 import subprocess
 import time
+from typing import Optional
+
+import psutil
 
 CRLF = "\r\n"
 
 
-def initialize_ssache():
+def initialize_ssache(port: int = 7777, args: Optional[str] = None):
     os.environ["RUST_LOG"] = "info"
-    command = ["./target/release/ssache"]
+    command = ["./target/release/ssache", "-p", str(port)]
+    if args is not None:
+        command.extend(args.split(" "))
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     # TODO: Instead of sleeping, loop waiting for the sucess log
     time.sleep(0.5)
     return process.pid
 
 
-def initialize_ssache_with_scheduled_save(interval):
-    os.environ["RUST_LOG"] = "info"
-    command = ["./target/release/ssache", "-e", "--save-job-interval", interval]
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    time.sleep(0.5)
-    return process.pid
+def find_and_kill_ssache_process():
+    # Workaround to kill the running ssache process and restart it
+    processes = psutil.process_iter()
+
+    name = "ssache"
+    ssache_process = [p for p in processes if name in p.name()][0]
+    os.kill(ssache_process.pid, signal.SIGTERM)
 
 
 def kill_ssache(pid):
@@ -31,11 +37,10 @@ def kill_ssache(pid):
 
 class SsacheClient:
     IP = "127.0.0.1"
-    PORT = 7777
 
-    def connect(self):
+    def connect(self, port: int = 7777):
         self.__socket = s.socket(s.AF_INET, s.SOCK_STREAM)
-        self.__socket.connect((self.IP, self.PORT))
+        self.__socket.connect((self.IP, port))
 
     def unknown(self):
         request = f"UNKNOWN{CRLF}"


### PR DESCRIPTION
Adds configurable replication, if there are any replicas configured, the the primary node will start to append all write operations(SET, INCR and DECR) to an operation log, this log is read by a background process to send all operations to the configured replicas. This process can run concurrently with other write operations because the log is only cleared after all operations are sent to the replicas. If there's an error sending the operation to any replica it'll be discarted and dropped from the log, there are no guarantees that the whole log will be sent to the replica.